### PR TITLE
Processing messages on a backend server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.pistonmaster</groupId>
     <artifactId>PistonFilter</artifactId>
-    <version>1.2.0</version>
+    <version>1.3.0</version>
     <packaging>jar</packaging>
 
     <name>PistonFilter</name>
@@ -185,6 +185,11 @@
             <artifactId>junit-jupiter-engine</artifactId>
             <version>5.8.2</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>4.9.3</version>
         </dependency>
         <dependency>
             <groupId>org.bstats</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,11 @@
             <version>4.9.3</version>
         </dependency>
         <dependency>
+            <groupId>com.squareup.moshi</groupId>
+            <artifactId>moshi</artifactId>
+            <version>1.13.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bukkit</artifactId>
             <version>3.0.0</version>

--- a/src/main/java/net/pistonmaster/pistonfilter/utils/BackendResponse.java
+++ b/src/main/java/net/pistonmaster/pistonfilter/utils/BackendResponse.java
@@ -1,0 +1,11 @@
+package net.pistonmaster.pistonfilter.utils;
+
+public class BackendResponse {
+    public boolean allowed;
+    public String replacement;
+
+    public BackendResponse(boolean allowed, String replacement) {
+        this.allowed = allowed;
+        this.replacement = replacement;
+    }
+}

--- a/src/main/java/net/pistonmaster/pistonfilter/utils/Message.java
+++ b/src/main/java/net/pistonmaster/pistonfilter/utils/Message.java
@@ -1,0 +1,11 @@
+package net.pistonmaster.pistonfilter.utils;
+
+public class Message {
+    public String username;
+    public String message;
+
+    public Message(String username, String message) {
+        this.username = username;
+        this.message = message;
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -21,3 +21,11 @@ banned-text:
   - ".ga"
   - ".gg"
   - ".io"
+backend-processing:
+  enable: true
+  strategy: "before" # before / after / exclusive
+  response-on-error: true
+  timeout: 1000
+  retries: 1
+  servers: # load balanced with round-robin
+    - http://localhost:25501

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -22,9 +22,9 @@ banned-text:
   - ".gg"
   - ".io"
 backend-processing:
-  enable: true
+  enable: false
   strategy: "before" # before / after / exclusive
-  response-on-error: true
+  allow-on-error: true
   timeout: 1000
   retries: 1
   servers: # load balanced with round-robin


### PR DESCRIPTION
This PR adds message processing on a separate server. It sends a POST request on one of the provided servers and if the response isn't 'true' it cancels the message. May be useful for some ai related stuff or just constantly updating custom rules.

## Config changes

```yml
backend-processing:
  enable: false
  strategy: "before" # before / after / exclusive
  allow-on-error: true
  timeout: 1000
  retries: 1
  servers: # load balanced with round-robin
    - http://localhost:25501
```

## Backend server I used for testing (nodejs)

```js
const fastify = require('fastify')({ logger: true })

fastify.post('/', async (request, reply) => {
  const { username, message } = request.body;
  console.log({ username, message });
  return {
    allowed: !message.match(/1\s*\+\s*1/g),
    replacement: message.match(/2/g) ? message.replace(/2/g, '3') : null
  };
})

const start = async () => {
  try {
    await fastify.listen(25501);
  } catch (err) {
    fastify.log.error(err);
    process.exit(1);
  }
}
start();
```